### PR TITLE
Add releases json generator

### DIFF
--- a/include/config.php
+++ b/include/config.php
@@ -1,13 +1,13 @@
 <?php
-define('APP_PATH', 'C:/domains/windows.php.net/');
-define('SNAPS_DIR', APP_PATH . 'docroot/downloads/snaps/');
-define('RELEASES_DIR', APP_PATH . 'docroot/downloads/releases/');
-define('QA_DIR', APP_PATH . 'docroot/downloads/qa/');
+define('APP_PATH', 'C:/domains/windows.php.net');
+define('SNAPS_DIR', APP_PATH . '/docroot/downloads/snaps/');
+define('RELEASES_DIR', APP_PATH . '/docroot/downloads/releases/');
+define('QA_DIR', APP_PATH . '/docroot/downloads/qa/');
 define('DATA_DIR', APP_PATH . '/data/');
 define('LIB_DIR', APP_PATH . '/include/');
 define('NEWS_DIR', APP_PATH . '/news/');
 define('TPL_PATH', APP_PATH . '/templates/');
-define('DOCROOT', APP_PATH . '/docroot');
+define('DOCROOT', APP_PATH . '/docroot/');
 define('SNAPS_URL', '/downloads/snaps/');
 
 define('MODE_RELEASE', 0);

--- a/include/listing.php
+++ b/include/listing.php
@@ -20,6 +20,10 @@ function processSha1Sums($snaps_dir)
     $sha1sums = file($snaps_dir . '/sha1sum.txt');
     $res = array();
     foreach ($sha1sums as $sha1) {
+        if (false === strpos($sha1, '  ')) {
+            continue;
+        }
+
         list($sha1, $file) = explode('  ', $sha1);
         $file = str_replace(array("\r", "\n", $snaps_dir), array('', '', ''), $file);
         $res[strtolower(basename($file))] = $sha1;

--- a/include/listing.php
+++ b/include/listing.php
@@ -140,6 +140,7 @@ function generate_listing($path, $nmode)
         $releases[$version_short][$key]['mtime'] = $mtime;
         $releases[$version_short][$key]['zip'] = array(
             'path' => $file_ori,
+            'link' => generate_download_link($file_ori, $nmode),
             'size' => bytes2string(filesize($file_ori)),
             'sha1' => $sha1sums[strtolower($file_ori)] ?? null,
             'sha256' => $sha256sums[strtolower($file_ori)]
@@ -163,6 +164,7 @@ function generate_listing($path, $nmode)
         if (file_exists($source)) {
             $releases[$version_short]['source'] = array(
                 'path' => $source,
+                'link' => generate_download_link($source, $nmode),
                 'size' => bytes2string(filesize($source))
             );
         }
@@ -170,6 +172,7 @@ function generate_listing($path, $nmode)
             $releases[$version_short][$key]['debug_pack'] = array(
                 'size' => bytes2string(filesize($debug_pack)),
                 'path' => $debug_pack,
+                'link' => generate_download_link($debug_pack, $nmode),
                 'sha1' => $sha1sums[strtolower($debug_pack)] ?? null,
                 'sha256' => $sha256sums[strtolower($debug_pack)]
             );
@@ -178,6 +181,7 @@ function generate_listing($path, $nmode)
             $releases[$version_short][$key]['devel_pack'] = array(
                 'size' => bytes2string(filesize($devel_pack)),
                 'path' => $devel_pack,
+                'link' => generate_download_link($devel_pack, $nmode),
                 'sha1' => $sha1sums[strtolower($devel_pack)] ?? null,
                 'sha256' => $sha256sums[strtolower($devel_pack)]
             );
@@ -186,6 +190,7 @@ function generate_listing($path, $nmode)
             $releases[$version_short][$key]['installer'] = array(
                 'size' => bytes2string(filesize($installer)),
                 'path' => $installer,
+                'link' => generate_download_link($installer, $nmode),
                 'sha1' => $sha1sums[strtolower($installer)] ?? null,
                 'sha256' => $sha256sums[strtolower($installer)]
             );
@@ -194,6 +199,7 @@ function generate_listing($path, $nmode)
             $releases[$version_short]['test_pack'] = array(
                 'size' => bytes2string(filesize($testpack)),
                 'path' => $testpack,
+                'link' => generate_download_link($testpack, $nmode),
                 'sha1' => $sha1sums[strtolower($testpack)] ?? null,
                 'sha256' => $sha256sums[strtolower($testpack)]
             );
@@ -363,6 +369,29 @@ function generate_latest_releases_html(array $releases = array())
     }
 
     return true;
+}
+
+function generate_download_link(string $filename, int $mode) : string
+{
+    switch ($mode) {
+        case MODE_RELEASE:
+            $path = 'releases/';
+            break;
+
+        case MODE_SNAP:
+            $path = 'snaps/';
+            break;
+
+        case MODE_QA:
+            $path = 'qa/';
+            break;
+
+        default:
+            $message = sprintf('Provided mode "%s" is not supported.', $mode);
+            throw new InvalidArgumentException($message);
+    }
+
+    return 'https://windows.php.net/downloads/' . $path . $filename;
 }
 
 /*

--- a/include/listing.php
+++ b/include/listing.php
@@ -25,7 +25,7 @@ function processSha1Sums($snaps_dir)
         }
 
         list($sha1, $file) = explode('  ', $sha1);
-        $file = str_replace(array("\r", "\n", $snaps_dir), array('', '', ''), $file);
+        $file = str_replace(array("\r", "\n", $snaps_dir), '', $file);
         $res[strtolower(basename($file))] = $sha1;
     }
     return $res;

--- a/include/listing.php
+++ b/include/listing.php
@@ -1,328 +1,326 @@
 <?php
 
-function bytes2string($size, $precision = 2) {
-	$sizes = array('YB', 'ZB', 'EB', 'PB', 'TB', 'GB', 'MB', 'kB', 'B');
-	$total = count($sizes);
+function bytes2string($size, $precision = 2)
+{
+    $sizes = array('YB', 'ZB', 'EB', 'PB', 'TB', 'GB', 'MB', 'kB', 'B');
+    $total = count($sizes);
 
-	while($total-- && $size > 1024) $size /= 1024;
+    while ($total-- && $size > 1024) {
+        $size /= 1024;
+    }
 
-	return round($size, $precision).$sizes[$total];
+    return round($size, $precision) . $sizes[$total];
 }
-
 
 function processSha1Sums($snaps_dir)
 {
-	if (!file_exists($snaps_dir . 'sha1sum.txt')) {
-		return array();
-	}
-	$sha1sums = file($snaps_dir . 'sha1sum.txt');
-	$res = array();
-	foreach ($sha1sums as $sha1){
-		list($sha1, $file) = explode('  ', $sha1);
-		$file = str_replace(array("\r","\n", $snaps_dir), array('','', ''), $file);
-		$res[strtolower(basename($file))] = $sha1;
-	}
-	return $res;
+    if (!file_exists($snaps_dir . 'sha1sum.txt')) {
+        return array();
+    }
+    $sha1sums = file($snaps_dir . 'sha1sum.txt');
+    $res = array();
+    foreach ($sha1sums as $sha1) {
+        list($sha1, $file) = explode('  ', $sha1);
+        $file = str_replace(array("\r", "\n", $snaps_dir), array('', '', ''), $file);
+        $res[strtolower(basename($file))] = $sha1;
+    }
+    return $res;
 }
-
 
 function processSha256Sums($snaps_dir)
 {
-	if (!file_exists($snaps_dir . 'sha256sum.txt')) {
-		return array();
-	}
-	$sha256sums = file($snaps_dir . 'sha256sum.txt');
-	$res = array();
-	foreach ($sha256sums as $sha256){
-		list($sha256, $file) = preg_split("/\s+\*?/", $sha256);
-		$file = str_replace(array("\r","\n", $snaps_dir), array('','', ''), $file);
-		$res[strtolower(basename($file))] = $sha256;
-	}
-	return $res;
+    if (!file_exists($snaps_dir . 'sha256sum.txt')) {
+        return array();
+    }
+    $sha256sums = file($snaps_dir . 'sha256sum.txt');
+    $res = array();
+    foreach ($sha256sums as $sha256) {
+        list($sha256, $file) = preg_split("/\s+\*?/", $sha256);
+        $file = str_replace(array("\r", "\n", $snaps_dir), array('', '', ''), $file);
+        $res[strtolower(basename($file))] = $sha256;
+    }
+    return $res;
 }
-
 
 function parse_file_name($v)
 {
-	$v = str_replace(array('-Win32', '.zip'), array('', ''), $v);
+    $v = str_replace(array('-Win32', '.zip'), array('', ''), $v);
 
-	$elms = explode('-', $v);
-	if (is_numeric($elms[2]) || $elms[2] == 'dev') {
-		$version = $elms[1] . '-' . $elms[2];
-		$nts = $elms[3] == 'nts' ? 'nts' : false;
-		if ($nts) {
-			$vc = $elms[4];
-			$arch = $elms[5];
-		} else {
-			$vc = $elms[3];
-			$arch = $elms[4];
-		}
-	} elseif ($elms[2] == 'nts') {
-		$nts = 'nts';
-		$version = $elms[1];
-		$vc = $elms[3];
-		$arch = $elms[4];
-	} else {
-		$nts = false;
-		$version = $elms[1];
-		$vc = $elms[2];
-		$arch = $elms[3];
-	}
-	if (is_numeric($vc)) {
-		$vc = 'VC6';
-		$arch = 'x86';
-	}
-	$t = count($elms) - 1;
-	$ts = is_numeric($elms[$t]) ? $elms[$t] : false;
+    $elms = explode('-', $v);
+    if (is_numeric($elms[2]) || $elms[2] == 'dev') {
+        $version = $elms[1] . '-' . $elms[2];
+        $nts = $elms[3] == 'nts' ? 'nts' : false;
+        if ($nts) {
+            $vc = $elms[4];
+            $arch = $elms[5];
+        } else {
+            $vc = $elms[3];
+            $arch = $elms[4];
+        }
+    } elseif ($elms[2] == 'nts') {
+        $nts = 'nts';
+        $version = $elms[1];
+        $vc = $elms[3];
+        $arch = $elms[4];
+    } else {
+        $nts = false;
+        $version = $elms[1];
+        $vc = $elms[2];
+        $arch = $elms[3];
+    }
+    if (is_numeric($vc)) {
+        $vc = 'VC6';
+        $arch = 'x86';
+    }
+    $t = count($elms) - 1;
+    $ts = is_numeric($elms[$t]) ? $elms[$t] : false;
 
-	return array(
-			'version'  => $version,
-			'version_short'  => substr($version, 0, 3),
-			'nts'      => $nts,
-			'vc'       => $vc,
-			'arch'     => $arch,
-			'ts'       => $ts
-			);
+    return array(
+        'version' => $version,
+        'version_short' => substr($version, 0, 3),
+        'nts' => $nts,
+        'vc' => $vc,
+        'arch' => $arch,
+        'ts' => $ts
+    );
 }
 
-function generate_listing($path, $nmode) {
-	$lck = fopen(DATA_DIR . DIRECTORY_SEPARATOR . 'site_generate_listing.lock', 'wb');
-	flock($lck, LOCK_EX);
+function generate_listing($path, $nmode)
+{
+    $lck = fopen(DATA_DIR . DIRECTORY_SEPARATOR . 'site_generate_listing.lock', 'wb');
+    flock($lck, LOCK_EX);
 
-	if (file_exists($path . '/cache.info')) {
-		include $path . '/cache.info';
-		flock($lck, LOCK_UN);
-		fclose($lck);
-		return $releases;
-	}
+    if (file_exists($path . '/cache.info')) {
+        include $path . '/cache.info';
+        flock($lck, LOCK_UN);
+        fclose($lck);
+        return $releases;
+    }
 
-	$old_cwd = getcwd();
-	chdir($path);
+    $old_cwd = getcwd();
+    chdir($path);
 
-	$versions = glob('php-[67].*[0-9]-latest.zip');
-	if (empty($versions)) {
-		$versions = glob('php-[67].*[0-9].zip');
-	}
+    $versions = glob('php-[67].*[0-9]-latest.zip');
+    if (empty($versions)) {
+        $versions = glob('php-[67].*[0-9].zip');
+    }
 
-	$releases = array();
-	$sha1sums = processSha1Sums($path);
-	$sha256sums = processSha256Sums($path);
-	foreach ($versions as $file) {
-		$file_ori = $file;
-		if (MODE_SNAP === $nmode) {
-			$file = readlink($file);
-		}
-		$datetime_str = substr($file, strlen($file) - 16, 12);
-		if (!preg_match('/([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})/', $datetime_str, $m)) {
-			$mtime = date('Y-M-d H:i:s', filemtime($file));
-		} else {
-			$snap_time = date_create();
-			$snap_time->setDate($m[1], $m[2], $m[3]);
-			$snap_time->setTime( $m[4], $m[5], 0);
-			$mtime = date_format($snap_time, 'Y-M-d H:i:s');
-			$snap_time_suffix = $m[1] . $m[2] . $m[3] . $m[4] . $m[5];
-		}
+    $releases = array();
+    $sha1sums = processSha1Sums($path);
+    $sha256sums = processSha256Sums($path);
+    foreach ($versions as $file) {
+        $file_ori = $file;
+        if (MODE_SNAP === $nmode) {
+            $file = readlink($file);
+        }
+        $datetime_str = substr($file, strlen($file) - 16, 12);
+        if (!preg_match('/([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})/', $datetime_str, $m)) {
+            $mtime = date('Y-M-d H:i:s', filemtime($file));
+        } else {
+            $snap_time = date_create();
+            $snap_time->setDate($m[1], $m[2], $m[3]);
+            $snap_time->setTime($m[4], $m[5], 0);
+            $mtime = date_format($snap_time, 'Y-M-d H:i:s');
+            $snap_time_suffix = $m[1] . $m[2] . $m[3] . $m[4] . $m[5];
+        }
 
+        $elms = parse_file_name(basename($file));
+        $key = ($elms['nts'] ? 'nts-' : 'ts-') . $elms['vc'] . '-' . $elms['arch'];
+        $version_short = $elms['version_short'];
+        if (!isset($releases['version'])) {
+            $releases[$version_short]['version'] = $elms['version'];
+        }
+        $releases[$version_short][$key]['mtime'] = $mtime;
+        $releases[$version_short][$key]['zip'] = array(
+            'path' => $file_ori,
+            'size' => bytes2string(filesize($file_ori)),
+            'sha1' => $sha1sums[strtolower($file_ori)],
+            'sha256' => $sha256sums[strtolower($file_ori)]
+        );
+        $compile = $configure = $buildconf = false;
+        if (MODE_SNAP === $nmode) {
+            $debug_pack = 'php-debug-pack-' . $elms['version_short'] . ($elms['nts'] ? '-' . $elms['nts'] : '') . '-win32' . ($elms['ts'] ? '-' . $elms['vc'] . '-' . $elms['arch'] . '-latest' : '') . '.zip';
+            $installer = 'php-' . $elms['version_short'] . ($elms['nts'] ? '-' . $elms['nts'] : '') . '-win32' . ($elms['ts'] ? '-' . $elms['vc'] . '-' . $elms['arch'] . '-latest' : '') . '.msi';
+            $testpack = 'php-test-pack-' . $elms['version_short'] . '-latest.zip';
+            $source = 'php-' . $elms['version_short'] . '/php-' . $elms['version_short'] . '-src-latest.zip';
+            $configure = 'configure-' . $elms['version_short'] . '-' . $elms['vc'] . '-' . $elms['arch'] . '-' . ($elms['nts'] ? $elms['nts'] . '-' : '') . $snap_time_suffix . '.log';
+            $compile = 'compile-' . $elms['version_short'] . '-' . $elms['vc'] . '-' . $elms['arch'] . '-' . ($elms['nts'] ? $elms['nts'] . '-' : '') . $snap_time_suffix . '.log';
+            $buildconf = 'buildconf-' . $elms['version_short'] . '-' . $elms['vc'] . '-' . $elms['arch'] . '-' . ($elms['nts'] ? $elms['nts'] . '-' : '') . $snap_time_suffix . '.log';
+        } else {
+            $debug_pack = 'php-debug-pack-' . $elms['version'] . ($elms['nts'] ? '-' . $elms['nts'] : '') . '-Win32-' . $elms['vc'] . '-' . $elms['arch'] . ($elms['ts'] ? '-' . $elms['ts'] : '') . '.zip';
+            $devel_pack = 'php-devel-pack-' . $elms['version'] . ($elms['nts'] ? '-' . $elms['nts'] : '') . '-Win32-' . $elms['vc'] . '-' . $elms['arch'] . ($elms['ts'] ? '-' . $elms['ts'] : '') . '.zip';
+            $installer = 'php-' . $elms['version'] . ($elms['nts'] ? '-' . $elms['nts'] : '') . '-Win32-' . $elms['vc'] . '-' . $elms['arch'] . ($elms['ts'] ? '-' . $elms['ts'] : '') . '.msi';
+            $testpack = 'php-test-pack-' . $elms['version'] . '.zip';
+            $source = 'php-' . $elms['version'] . '-src.zip';
+        }
+        if (file_exists($source)) {
+            $releases[$version_short]['source'] = array(
+                'path' => $source,
+                'size' => bytes2string(filesize($source))
+            );
+        }
+        if (file_exists($debug_pack)) {
+            $releases[$version_short][$key]['debug_pack'] = array(
+                'size' => bytes2string(filesize($debug_pack)),
+                'path' => $debug_pack,
+                'sha1' => $sha1sums[strtolower($debug_pack)],
+                'sha256' => $sha256sums[strtolower($debug_pack)]
+            );
+        }
+        if (file_exists($devel_pack)) {
+            $releases[$version_short][$key]['devel_pack'] = array(
+                'size' => bytes2string(filesize($devel_pack)),
+                'path' => $devel_pack,
+                'sha1' => $sha1sums[strtolower($devel_pack)],
+                'sha256' => $sha256sums[strtolower($devel_pack)]
+            );
+        }
+        if (file_exists($installer)) {
+            $releases[$version_short][$key]['installer'] = array(
+                'size' => bytes2string(filesize($installer)),
+                'path' => $installer,
+                'sha1' => $sha1sums[strtolower($installer)],
+                'sha256' => $sha256sums[strtolower($installer)]
+            );
+        }
+        if (file_exists($testpack)) {
+            $releases[$version_short]['test_pack'] = array(
+                'size' => bytes2string(filesize($testpack)),
+                'path' => $testpack,
+                'sha1' => $sha1sums[strtolower($testpack)],
+                'sha256' => $sha256sums[strtolower($testpack)]
+            );
+        }
 
-		$elms = parse_file_name(basename($file));
-		$key = ($elms['nts'] ? 'nts-' : 'ts-') . $elms['vc'] . '-' . $elms['arch'];
-		$version_short = $elms['version_short'];
-		if (!isset($releases['version'])) {
-			$releases[$version_short]['version'] = $elms['version'];
-		}
-		$releases[$version_short][$key]['mtime'] = $mtime;
-		$releases[$version_short][$key]['zip'] = array(
-				'path' => $file_ori,
-				'size' => bytes2string(filesize($file_ori)),
-				'sha1' => $sha1sums[strtolower($file_ori)],
-				'sha256' => $sha256sums[strtolower($file_ori)]
-				);
-		$compile = $configure = $buildconf = false;
-		if (MODE_SNAP === $nmode) {
-			$debug_pack = 'php-debug-pack-' . $elms['version_short'] . ($elms['nts'] ? '-' . $elms['nts'] : '') . '-win32' . ($elms['ts'] ? '-' . $elms['vc'] . '-' . $elms['arch'] . '-latest' : '') . '.zip';
-			$installer =  'php-' . $elms['version_short'] . ($elms['nts'] ? '-' . $elms['nts'] : '') . '-win32' . ($elms['ts'] ? '-' . $elms['vc'] . '-' . $elms['arch'] . '-latest' : '') . '.msi';
-			$testpack = 'php-test-pack-' . $elms['version_short'] . '-latest.zip';
-			$source     = 'php-' . $elms['version_short'] . '/php-' . $elms['version_short'] . '-src-latest.zip';
-			$configure  = 'configure-' . $elms['version_short'] . '-' . $elms['vc'] . '-' . $elms['arch'] . '-' . ($elms['nts'] ? $elms['nts'] . '-' : '') .  $snap_time_suffix . '.log';
-			$compile    = 'compile-' . $elms['version_short'] . '-' . $elms['vc'] . '-' . $elms['arch'] . '-' . ($elms['nts'] ? $elms['nts'] . '-' : '') . $snap_time_suffix . '.log';
-			$buildconf  = 'buildconf-'. $elms['version_short'] . '-' . $elms['vc'] . '-' . $elms['arch'] . '-' . ($elms['nts'] ? $elms['nts'] . '-' : '') . $snap_time_suffix . '.log';
-		} else {
-			$debug_pack = 'php-debug-pack-' . $elms['version'] . ($elms['nts'] ? '-' . $elms['nts'] : '') . '-Win32-' . $elms['vc'] . '-' . $elms['arch'] . ($elms['ts'] ? '-' . $elms['ts'] : '') . '.zip';
-			$devel_pack = 'php-devel-pack-' . $elms['version'] . ($elms['nts'] ? '-' . $elms['nts'] : '') . '-Win32-' . $elms['vc'] . '-' . $elms['arch'] . ($elms['ts'] ? '-' . $elms['ts'] : '') . '.zip';
-			$installer =  'php-' . $elms['version'] . ($elms['nts'] ? '-' . $elms['nts'] : '') . '-Win32-' . $elms['vc'] . '-' . $elms['arch'] . ($elms['ts'] ? '-' . $elms['ts'] : '') . '.msi';
-			$testpack = 'php-test-pack-' . $elms['version'] . '.zip';
-			$source = 'php-' . $elms['version'] . '-src.zip';
-		}
-		if (file_exists($source)) {
-			$releases[$version_short]['source'] = array(
-					'path' => $source,
-					'size' => bytes2string(filesize($source))
-					);
-		}
-		if (file_exists($debug_pack)) {
-			$releases[$version_short][$key]['debug_pack'] = array(
-					'size' => bytes2string(filesize($debug_pack)),
-					'path' => $debug_pack,
-					'sha1' => $sha1sums[strtolower($debug_pack)],
-					'sha256' => $sha256sums[strtolower($debug_pack)]
-						);
-		}
-		if (file_exists($devel_pack)) {
-			$releases[$version_short][$key]['devel_pack'] = array(
-					'size' => bytes2string(filesize($devel_pack)),
-					'path' => $devel_pack,
-					'sha1' => $sha1sums[strtolower($devel_pack)],
-					'sha256' => $sha256sums[strtolower($devel_pack)]
-						);
-		}
-		if (file_exists($installer)) {
-			$releases[$version_short][$key]['installer'] = array(
-					'size' => bytes2string(filesize($installer)),
-					'path' => $installer,
-					'sha1' => $sha1sums[strtolower($installer)],
-					'sha256' => $sha256sums[strtolower($installer)]
-						);
-		}
-		if (file_exists($testpack)) {
-			$releases[$version_short]['test_pack'] = array(
-					'size' => bytes2string(filesize($testpack)),
-					'path' => $testpack,
-					'sha1' => $sha1sums[strtolower($testpack)],
-					'sha256' => $sha256sums[strtolower($testpack)]
-						);
-		}
+        if (MODE_SNAP === $nmode) {
+            if ($buildconf) {
+                $releases[$version_short][$key]['buildconf'] = $buildconf;
+            }
+            if ($compile) {
+                $releases[$version_short][$key]['compile'] = $compile;
+            }
+            if ($configure) {
+                $releases[$version_short][$key]['configure'] = $configure;
+            }
+        }
+    }
 
+    $cache_content = '<?php $releases = ' . var_export($releases, true) . ';';
+    $tmp_name = tempnam('.', '_cachinfo');
+    file_put_contents($tmp_name, $cache_content);
+    rename($tmp_name, 'cache.info');
+    chdir($old_cwd);
 
-		if (MODE_SNAP === $nmode) {
-			if ($buildconf) {
-				$releases[$version_short][$key]['buildconf'] = $buildconf;
-			}
-			if ($compile) {
-				$releases[$version_short][$key]['compile'] = $compile;
-			}
-			if ($configure) {
-				$releases[$version_short][$key]['configure'] = $configure;
-			}
-		}
-	}
+    if (MODE_RELEASE === $nmode) {
+        generate_web_config($releases);
+        generate_latest_releases_html($releases);
+    }
 
-	$cache_content = '<?php $releases = ' . var_export($releases, true) . ';';
-	$tmp_name = tempnam('.', '_cachinfo');
-	file_put_contents($tmp_name, $cache_content);
-	rename($tmp_name, 'cache.info');
-	chdir($old_cwd);
+    flock($lck, LOCK_UN);
+    fclose($lck);
 
-	if (MODE_RELEASE === $nmode) {
-		generate_web_config($releases);
-		generate_latest_releases_html($releases);
-	}
-
-	flock($lck, LOCK_UN);
-	fclose($lck);
-
-	return $releases;
+    return $releases;
 }
 
 function transform_fname_to_latest($fname_real, $ver, $cur_ver)
 {
-	$ret = implode($ver, explode($cur_ver, $fname_real));
-	$ret = str_replace('.zip', '-latest.zip', $ret);
+    $ret = implode($ver, explode($cur_ver, $fname_real));
+    $ret = str_replace('.zip', '-latest.zip', $ret);
 
-	return $ret;
+    return $ret;
 }
 
 function get_redirection_conf_piece($tpl, $fname_real, $ver, $cur_ver)
 {
-	$real_fname_path = RELEASES_DIR . $fname_real;
-	if ('.zip' != substr($fname_real, strlen($fname_real)-4) || !is_file($real_fname_path)) {
-		/* This might be something invalid like a partially uploaded file or wrong path, don't generate anything. */
-		return '';
-	}
+    $real_fname_path = RELEASES_DIR . $fname_real;
+    if ('.zip' != substr($fname_real, strlen($fname_real) - 4) || !is_file($real_fname_path)) {
+        /* This might be something invalid like a partially uploaded file or wrong path, don't generate anything. */
+        return '';
+    }
 
-	$search = array('REAL_FILENAME', 'FAKE_FILENAME');
-	$fname_fake = transform_fname_to_latest($fname_real, $ver, $cur_ver);
-	$ret = str_replace($search, array($fname_real, $fname_fake), $tpl);
+    $search = array('REAL_FILENAME', 'FAKE_FILENAME');
+    $fname_fake = transform_fname_to_latest($fname_real, $ver, $cur_ver);
+    $ret = str_replace($search, array($fname_real, $fname_fake), $tpl);
 
-	return $ret . "\n\t\t";
+    return $ret . "\n\t\t";
 }
 
 function generate_web_config(array $releases = array())
 {
-	$config_tpl = file_get_contents(TPL_PATH . '/web.config.tpl');
-	$redirect_tpl = trim(file_get_contents(TPL_PATH . '/web.config.rewrite.tpl'));
+    $config_tpl = file_get_contents(TPL_PATH . '/web.config.tpl');
+    $redirect_tpl = trim(file_get_contents(TPL_PATH . '/web.config.rewrite.tpl'));
 
-	/* Handle releases. */
-	if (empty($releases)) {
-		$cache = DOCROOT . '/downloads/releases/cache.info';
-		if (!file_exists($cache)) {
-			return false;
-		}
-		include $cache;
-	}
+    /* Handle releases. */
+    if (empty($releases)) {
+        $cache = DOCROOT . '/downloads/releases/cache.info';
+        if (!file_exists($cache)) {
+            return false;
+        }
+        include $cache;
+    }
 
-	$tmp = '';
-	foreach ($releases as $version => $release) {
+    $tmp = '';
+    foreach ($releases as $version => $release) {
 
-		$cur_ver = $release['version'];
-		unset($release['version']);
+        $cur_ver = $release['version'];
+        unset($release['version']);
 
-		$tmp .= "\t\t\t<!--  redirect to latest downloads php-$version -->\n\t\t";
+        $tmp .= "\t\t\t<!--  redirect to latest downloads php-$version -->\n\t\t";
 
-		$tmp .= get_redirection_conf_piece($redirect_tpl, $release['source']['path'], $version, $cur_ver);
-		unset($release['source']);
-		$tmp .= get_redirection_conf_piece($redirect_tpl, $release['test_pack']['path'], $version, $cur_ver);
-		unset($release['test_pack']);
+        $tmp .= get_redirection_conf_piece($redirect_tpl, $release['source']['path'], $version, $cur_ver);
+        unset($release['source']);
+        $tmp .= get_redirection_conf_piece($redirect_tpl, $release['test_pack']['path'], $version, $cur_ver);
+        unset($release['test_pack']);
 
-		foreach ($release as $flavour) {
-			$tmp .= get_redirection_conf_piece($redirect_tpl, $flavour['zip']['path'], $version, $cur_ver);
-			$tmp .= get_redirection_conf_piece($redirect_tpl, $flavour['debug_pack']['path'], $version, $cur_ver);
-			$tmp .= get_redirection_conf_piece($redirect_tpl, $flavour['devel_pack']['path'], $version, $cur_ver);
-		}
-	}
+        foreach ($release as $flavour) {
+            $tmp .= get_redirection_conf_piece($redirect_tpl, $flavour['zip']['path'], $version, $cur_ver);
+            $tmp .= get_redirection_conf_piece($redirect_tpl, $flavour['debug_pack']['path'], $version, $cur_ver);
+            $tmp .= get_redirection_conf_piece($redirect_tpl, $flavour['devel_pack']['path'], $version, $cur_ver);
+        }
+    }
 
-	$config_content = str_replace('RELEASES_REDIRECT_TO_LATEST_PLACEHOLDER', $tmp, $config_tpl);
+    $config_content = str_replace('RELEASES_REDIRECT_TO_LATEST_PLACEHOLDER', $tmp, $config_tpl);
+    
+    /* Save generated web.config. */
+    $config_path = DOCROOT . '/web.config';
+    if (strlen($config_content) !== file_put_contents($config_path, $config_content, LOCK_EX)) {
+        return false;
+    }
 
-
-	/* Save generated web.config. */
-	$config_path = DOCROOT . '/web.config';
-	if (strlen($config_content) !== file_put_contents($config_path, $config_content, LOCK_EX)) {
-		return false;
-	}
-
-	return true;
+    return true;
 }
 
 function generate_latest_html_piece($fname, $ts, $size, $ver, $cur_ver)
 {
-	$tpl = " DATETIME     SIZE <a href=\"/downloads/releases/latest/FNAME\">FNAME</a>\n";
+    $tpl = " DATETIME     SIZE <a href=\"/downloads/releases/latest/FNAME\">FNAME</a>\n";
 
-	$fn = transform_fname_to_latest($fname, $ver, $cur_ver);
+    $fn = transform_fname_to_latest($fname, $ver, $cur_ver);
 
-	return str_replace(
-		array('DATETIME', 'SIZE', 'FNAME'),
-		array(date('m/d/Y h:i A', $ts), str_pad((int)$size, 8, ' ', STR_PAD_LEFT), $fn),
-		$tpl
-	);
+    return str_replace(
+        array('DATETIME', 'SIZE', 'FNAME'),
+        array(date('m/d/Y h:i A', $ts), str_pad((int)$size, 8, ' ', STR_PAD_LEFT), $fn),
+        $tpl
+    );
 }
 
 function generate_latest_releases_html(array $releases = array())
 {
-	$index_html_tpl = trim(file_get_contents(TPL_PATH . '/releases_latest.tpl'));
-	$index_html_path = DOCROOT . '/downloads/releases/latest/index.html';
+    $index_html_tpl = trim(file_get_contents(TPL_PATH . '/releases_latest.tpl'));
+    $index_html_path = DOCROOT . '/downloads/releases/latest/index.html';
 
-	/* Handle releases. */
-	if (empty($releases)) {
-		$cache = DOCROOT . '/downloads/releases/cache.info';
-		if (!file_exists($cache)) {
-			return false;
-		}
-		include $cache;
-	}
+    /* Handle releases. */
+    if (empty($releases)) {
+        $cache = DOCROOT . '/downloads/releases/cache.info';
+        if (!file_exists($cache)) {
+            return false;
+        }
+        include $cache;
+    }
 
-	$tmp = '';
-	foreach ($releases as $version => $release) {
-		$cur_ver = $release['version'];
-		unset($release['version']);
+    $tmp = '';
+    foreach ($releases as $version => $release) {
+        $cur_ver = $release['version'];
+        unset($release['version']);
 
 		/* TODO Src date and size should be cached but it's currently absent. */
 		$src_path = DOCROOT . '/downloads/releases/' . $release['source']['path'];
@@ -336,8 +334,8 @@ function generate_latest_releases_html(array $releases = array())
 		$tmp .= generate_latest_html_piece($release['test_pack']['path'], $test_pack_mtime, $test_pack_size, $version, $cur_ver);
 		unset($release['test_pack']);
 
-		foreach ($release as $flavour) {
-			$mtime = strtotime($flavour['mtime']);
+        foreach ($release as $flavour) {
+            $mtime = strtotime($flavour['mtime']);
 
 			$tmp .= generate_latest_html_piece($flavour['zip']['path'], $mtime, (float)$flavour['zip']['size']*1024*1024, $version, $cur_ver);
 			$tmp .= generate_latest_html_piece($flavour['debug_pack']['path'], $mtime, (float)$flavour['debug_pack']['size']*1024*1024, $version, $cur_ver);
@@ -345,19 +343,19 @@ function generate_latest_releases_html(array $releases = array())
 		}
 	}
 
-	$index_html_content = str_replace('RELEASES_LIST_PLACEHOLDER', $tmp, $index_html_tpl);
+    $index_html_content = str_replace('RELEASES_LIST_PLACEHOLDER', $tmp, $index_html_tpl);
 
-	if (!is_dir(dirname($index_html_path))) {
-		if (!mkdir(dirname($index_html_path))) {
-			return false;
-		}
-	}
+    if (!is_dir(dirname($index_html_path))) {
+        if (!mkdir(dirname($index_html_path))) {
+            return false;
+        }
+    }
 
-	if (strlen($index_html_content) !== file_put_contents($index_html_path, $index_html_content, LOCK_EX)) {
-		return false;
-	}
+    if (strlen($index_html_content) !== file_put_contents($index_html_path, $index_html_content, LOCK_EX)) {
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 /*

--- a/include/listing.php
+++ b/include/listing.php
@@ -138,7 +138,7 @@ function generate_listing($path, $nmode)
         $releases[$version_short][$key]['zip'] = array(
             'path' => $file_ori,
             'size' => bytes2string(filesize($file_ori)),
-            'sha1' => $sha1sums[strtolower($file_ori)],
+            'sha1' => $sha1sums[strtolower($file_ori)] ?? null,
             'sha256' => $sha256sums[strtolower($file_ori)]
         );
         $compile = $configure = $buildconf = false;
@@ -167,7 +167,7 @@ function generate_listing($path, $nmode)
             $releases[$version_short][$key]['debug_pack'] = array(
                 'size' => bytes2string(filesize($debug_pack)),
                 'path' => $debug_pack,
-                'sha1' => $sha1sums[strtolower($debug_pack)],
+                'sha1' => $sha1sums[strtolower($debug_pack)] ?? null,
                 'sha256' => $sha256sums[strtolower($debug_pack)]
             );
         }
@@ -175,7 +175,7 @@ function generate_listing($path, $nmode)
             $releases[$version_short][$key]['devel_pack'] = array(
                 'size' => bytes2string(filesize($devel_pack)),
                 'path' => $devel_pack,
-                'sha1' => $sha1sums[strtolower($devel_pack)],
+                'sha1' => $sha1sums[strtolower($devel_pack)] ?? null,
                 'sha256' => $sha256sums[strtolower($devel_pack)]
             );
         }
@@ -183,7 +183,7 @@ function generate_listing($path, $nmode)
             $releases[$version_short][$key]['installer'] = array(
                 'size' => bytes2string(filesize($installer)),
                 'path' => $installer,
-                'sha1' => $sha1sums[strtolower($installer)],
+                'sha1' => $sha1sums[strtolower($installer)] ?? null,
                 'sha256' => $sha256sums[strtolower($installer)]
             );
         }
@@ -191,7 +191,7 @@ function generate_listing($path, $nmode)
             $releases[$version_short]['test_pack'] = array(
                 'size' => bytes2string(filesize($testpack)),
                 'path' => $testpack,
-                'sha1' => $sha1sums[strtolower($testpack)],
+                'sha1' => $sha1sums[strtolower($testpack)] ?? null,
                 'sha256' => $sha256sums[strtolower($testpack)]
             );
         }

--- a/include/listing.php
+++ b/include/listing.php
@@ -94,6 +94,9 @@ function generate_listing($path, $nmode)
     $lck = fopen(DATA_DIR . DIRECTORY_SEPARATOR . 'site_generate_listing.lock', 'wb');
     flock($lck, LOCK_EX);
 
+    // Setting path absolute to support execution from command line
+    $path = DOCROOT . $path;
+
     if (file_exists($path . '/cache.info')) {
         include $path . '/cache.info';
         flock($lck, LOCK_UN);
@@ -110,8 +113,8 @@ function generate_listing($path, $nmode)
     }
 
     $releases = array();
-    $sha1sums = processSha1Sums(DOCROOT . $path);
-    $sha256sums = processSha256Sums(DOCROOT . $path);
+    $sha1sums = processSha1Sums($path);
+    $sha256sums = processSha256Sums($path);
     foreach ($versions as $file) {
         $file_ori = $file;
         if (MODE_SNAP === $nmode) {

--- a/include/listing.php
+++ b/include/listing.php
@@ -14,10 +14,10 @@ function bytes2string($size, $precision = 2)
 
 function processSha1Sums($snaps_dir)
 {
-    if (!file_exists($snaps_dir . 'sha1sum.txt')) {
+    if (!file_exists($snaps_dir . '/sha1sum.txt')) {
         return array();
     }
-    $sha1sums = file($snaps_dir . 'sha1sum.txt');
+    $sha1sums = file($snaps_dir . '/sha1sum.txt');
     $res = array();
     foreach ($sha1sums as $sha1) {
         list($sha1, $file) = explode('  ', $sha1);
@@ -29,10 +29,10 @@ function processSha1Sums($snaps_dir)
 
 function processSha256Sums($snaps_dir)
 {
-    if (!file_exists($snaps_dir . 'sha256sum.txt')) {
+    if (!file_exists($snaps_dir . '/sha256sum.txt')) {
         return array();
     }
-    $sha256sums = file($snaps_dir . 'sha256sum.txt');
+    $sha256sums = file($snaps_dir . '/sha256sum.txt');
     $res = array();
     foreach ($sha256sums as $sha256) {
         list($sha256, $file) = preg_split("/\s+\*?/", $sha256);
@@ -106,8 +106,8 @@ function generate_listing($path, $nmode)
     }
 
     $releases = array();
-    $sha1sums = processSha1Sums($path);
-    $sha256sums = processSha256Sums($path);
+    $sha1sums = processSha1Sums(DOCROOT . $path);
+    $sha256sums = processSha256Sums(DOCROOT . $path);
     foreach ($versions as $file) {
         $file_ori = $file;
         if (MODE_SNAP === $nmode) {
@@ -252,7 +252,7 @@ function generate_web_config(array $releases = array())
 
     /* Handle releases. */
     if (empty($releases)) {
-        $cache = DOCROOT . '/downloads/releases/cache.info';
+        $cache = DOCROOT . 'downloads/releases/cache.info';
         if (!file_exists($cache)) {
             return false;
         }
@@ -280,9 +280,9 @@ function generate_web_config(array $releases = array())
     }
 
     $config_content = str_replace('RELEASES_REDIRECT_TO_LATEST_PLACEHOLDER', $tmp, $config_tpl);
-    
+
     /* Save generated web.config. */
-    $config_path = DOCROOT . '/web.config';
+    $config_path = DOCROOT . 'web.config';
     if (strlen($config_content) !== file_put_contents($config_path, $config_content, LOCK_EX)) {
         return false;
     }
@@ -306,11 +306,11 @@ function generate_latest_html_piece($fname, $ts, $size, $ver, $cur_ver)
 function generate_latest_releases_html(array $releases = array())
 {
     $index_html_tpl = trim(file_get_contents(TPL_PATH . '/releases_latest.tpl'));
-    $index_html_path = DOCROOT . '/downloads/releases/latest/index.html';
+    $index_html_path = DOCROOT . 'downloads/releases/latest/index.html';
 
     /* Handle releases. */
     if (empty($releases)) {
-        $cache = DOCROOT . '/downloads/releases/cache.info';
+        $cache = DOCROOT . 'downloads/releases/cache.info';
         if (!file_exists($cache)) {
             return false;
         }
@@ -323,12 +323,12 @@ function generate_latest_releases_html(array $releases = array())
         unset($release['version']);
 
 		/* TODO Src date and size should be cached but it's currently absent. */
-		$src_path = DOCROOT . '/downloads/releases/' . $release['source']['path'];
+		$src_path = DOCROOT . 'downloads/releases/' . $release['source']['path'];
 		$src_mtime = isset($release['source']['mtime']) ? strtotime($release['source']['mtime']) : filemtime($src_path);
 		$src_size = isset($release['source']['size']) ? ((float)$release['source']['size']*1024*1024) : filesize($src_path);
 		$tmp .= generate_latest_html_piece($release['source']['path'], $src_mtime, $src_size, $version, $cur_ver);
 		unset($release['source']);
-		$test_pack_path = DOCROOT . '/downloads/releases/' . $release['test_pack']['path'];
+		$test_pack_path = DOCROOT . 'downloads/releases/' . $release['test_pack']['path'];
 		$test_pack_mtime = isset($release['test_pack']['mtime']) ? strtotime($release['test_pack']['mtime']) : filemtime($test_pack_path);
 		$test_pack_size = isset($release['test_pack']['size']) ? ((float)$release['test_pack']['size']*1024*1024) : filesize($test_pack_path);
 		$tmp .= generate_latest_html_piece($release['test_pack']['path'], $test_pack_mtime, $test_pack_size, $version, $cur_ver);

--- a/include/listing.php
+++ b/include/listing.php
@@ -86,7 +86,7 @@ function parse_file_name($v)
 }
 
 function generate_listing($path, $nmode) {
-	$lck = fopen(DATA_DIR . DIRECTORY_SEPARATOR . "site_generate_listing.lock", "wb");
+	$lck = fopen(DATA_DIR . DIRECTORY_SEPARATOR . 'site_generate_listing.lock', 'wb');
 	flock($lck, LOCK_EX);
 
 	if (file_exists($path . '/cache.info')) {
@@ -113,7 +113,7 @@ function generate_listing($path, $nmode) {
 			$file = readlink($file);
 		}
 		$datetime_str = substr($file, strlen($file) - 16, 12);
-		if (!preg_match("/([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})/", $datetime_str, $m)) {
+		if (!preg_match('/([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})/', $datetime_str, $m)) {
 			$mtime = date('Y-M-d H:i:s', filemtime($file));
 		} else {
 			$snap_time = date_create();
@@ -226,7 +226,7 @@ function generate_listing($path, $nmode) {
 function transform_fname_to_latest($fname_real, $ver, $cur_ver)
 {
 	$ret = implode($ver, explode($cur_ver, $fname_real));
-	$ret = str_replace(".zip", "-latest.zip", $ret);
+	$ret = str_replace('.zip', '-latest.zip', $ret);
 
 	return $ret;
 }
@@ -234,12 +234,12 @@ function transform_fname_to_latest($fname_real, $ver, $cur_ver)
 function get_redirection_conf_piece($tpl, $fname_real, $ver, $cur_ver)
 {
 	$real_fname_path = RELEASES_DIR . $fname_real;
-	if (".zip" != substr($fname_real, strlen($fname_real)-4) || !is_file($real_fname_path)) {
+	if ('.zip' != substr($fname_real, strlen($fname_real)-4) || !is_file($real_fname_path)) {
 		/* This might be something invalid like a partially uploaded file or wrong path, don't generate anything. */
-		return "";
+		return '';
 	}
 
-	$search = array("REAL_FILENAME", "FAKE_FILENAME");
+	$search = array('REAL_FILENAME', 'FAKE_FILENAME');
 	$fname_fake = transform_fname_to_latest($fname_real, $ver, $cur_ver);
 	$ret = str_replace($search, array($fname_real, $fname_fake), $tpl);
 
@@ -248,43 +248,43 @@ function get_redirection_conf_piece($tpl, $fname_real, $ver, $cur_ver)
 
 function generate_web_config(array $releases = array())
 {
-	$config_tpl = file_get_contents(TPL_PATH . "/web.config.tpl");
-	$redirect_tpl = trim(file_get_contents(TPL_PATH . "/web.config.rewrite.tpl"));
+	$config_tpl = file_get_contents(TPL_PATH . '/web.config.tpl');
+	$redirect_tpl = trim(file_get_contents(TPL_PATH . '/web.config.rewrite.tpl'));
 
 	/* Handle releases. */
 	if (empty($releases)) {
-		$cache = DOCROOT . "/downloads/releases/cache.info";
+		$cache = DOCROOT . '/downloads/releases/cache.info';
 		if (!file_exists($cache)) {
 			return false;
 		}
 		include $cache;
 	}
 
-	$tmp = "";
+	$tmp = '';
 	foreach ($releases as $version => $release) {
 
-		$cur_ver = $release["version"];
-		unset($release["version"]);
+		$cur_ver = $release['version'];
+		unset($release['version']);
 
 		$tmp .= "\t\t\t<!--  redirect to latest downloads php-$version -->\n\t\t";
 
-		$tmp .= get_redirection_conf_piece($redirect_tpl, $release["source"]["path"], $version, $cur_ver);
-		unset($release["source"]);
-		$tmp .= get_redirection_conf_piece($redirect_tpl, $release["test_pack"]["path"], $version, $cur_ver);
-		unset($release["test_pack"]);
+		$tmp .= get_redirection_conf_piece($redirect_tpl, $release['source']['path'], $version, $cur_ver);
+		unset($release['source']);
+		$tmp .= get_redirection_conf_piece($redirect_tpl, $release['test_pack']['path'], $version, $cur_ver);
+		unset($release['test_pack']);
 
 		foreach ($release as $flavour) {
-			$tmp .= get_redirection_conf_piece($redirect_tpl, $flavour["zip"]["path"], $version, $cur_ver);
-			$tmp .= get_redirection_conf_piece($redirect_tpl, $flavour["debug_pack"]["path"], $version, $cur_ver);
-			$tmp .= get_redirection_conf_piece($redirect_tpl, $flavour["devel_pack"]["path"], $version, $cur_ver);
+			$tmp .= get_redirection_conf_piece($redirect_tpl, $flavour['zip']['path'], $version, $cur_ver);
+			$tmp .= get_redirection_conf_piece($redirect_tpl, $flavour['debug_pack']['path'], $version, $cur_ver);
+			$tmp .= get_redirection_conf_piece($redirect_tpl, $flavour['devel_pack']['path'], $version, $cur_ver);
 		}
 	}
 
-	$config_content = str_replace("RELEASES_REDIRECT_TO_LATEST_PLACEHOLDER", $tmp, $config_tpl);
+	$config_content = str_replace('RELEASES_REDIRECT_TO_LATEST_PLACEHOLDER', $tmp, $config_tpl);
 
 
 	/* Save generated web.config. */
-	$config_path = DOCROOT . "/web.config";
+	$config_path = DOCROOT . '/web.config';
 	if (strlen($config_content) !== file_put_contents($config_path, $config_content, LOCK_EX)) {
 		return false;
 	}
@@ -299,53 +299,53 @@ function generate_latest_html_piece($fname, $ts, $size, $ver, $cur_ver)
 	$fn = transform_fname_to_latest($fname, $ver, $cur_ver);
 
 	return str_replace(
-		array("DATETIME", "SIZE", "FNAME"),
-		array(date("m/d/Y h:i A", $ts), str_pad((int)$size, 8, ' ', STR_PAD_LEFT), $fn),
+		array('DATETIME', 'SIZE', 'FNAME'),
+		array(date('m/d/Y h:i A', $ts), str_pad((int)$size, 8, ' ', STR_PAD_LEFT), $fn),
 		$tpl
 	);
 }
 
 function generate_latest_releases_html(array $releases = array())
 {
-	$index_html_tpl = trim(file_get_contents(TPL_PATH . "/releases_latest.tpl"));
-	$index_html_path = DOCROOT . "/downloads/releases/latest/index.html";
+	$index_html_tpl = trim(file_get_contents(TPL_PATH . '/releases_latest.tpl'));
+	$index_html_path = DOCROOT . '/downloads/releases/latest/index.html';
 
 	/* Handle releases. */
 	if (empty($releases)) {
-		$cache = DOCROOT . "/downloads/releases/cache.info";
+		$cache = DOCROOT . '/downloads/releases/cache.info';
 		if (!file_exists($cache)) {
 			return false;
 		}
 		include $cache;
 	}
 
-	$tmp = "";
+	$tmp = '';
 	foreach ($releases as $version => $release) {
-		$cur_ver = $release["version"];
-		unset($release["version"]);
+		$cur_ver = $release['version'];
+		unset($release['version']);
 
 		/* TODO Src date and size should be cached but it's currently absent. */
-		$src_path = DOCROOT . "/downloads/releases/" . $release["source"]["path"];
-		$src_mtime = isset($release["source"]["mtime"]) ? strtotime($release["source"]["mtime"]) : filemtime($src_path);
-		$src_size = isset($release["source"]["size"]) ? ((float)$release["source"]["size"]*1024*1024) : filesize($src_path);
-		$tmp .= generate_latest_html_piece($release["source"]["path"], $src_mtime, $src_size, $version, $cur_ver);
-		unset($release["source"]);
-		$test_pack_path = DOCROOT . "/downloads/releases/" . $release["test_pack"]["path"];
-		$test_pack_mtime = isset($release["test_pack"]["mtime"]) ? strtotime($release["test_pack"]["mtime"]) : filemtime($test_pack_path);
-		$test_pack_size = isset($release["test_pack"]["size"]) ? ((float)$release["test_pack"]["size"]*1024*1024) : filesize($test_pack_path);
-		$tmp .= generate_latest_html_piece($release["test_pack"]["path"], $test_pack_mtime, $test_pack_size, $version, $cur_ver);
-		unset($release["test_pack"]);
+		$src_path = DOCROOT . '/downloads/releases/' . $release['source']['path'];
+		$src_mtime = isset($release['source']['mtime']) ? strtotime($release['source']['mtime']) : filemtime($src_path);
+		$src_size = isset($release['source']['size']) ? ((float)$release['source']['size']*1024*1024) : filesize($src_path);
+		$tmp .= generate_latest_html_piece($release['source']['path'], $src_mtime, $src_size, $version, $cur_ver);
+		unset($release['source']);
+		$test_pack_path = DOCROOT . '/downloads/releases/' . $release['test_pack']['path'];
+		$test_pack_mtime = isset($release['test_pack']['mtime']) ? strtotime($release['test_pack']['mtime']) : filemtime($test_pack_path);
+		$test_pack_size = isset($release['test_pack']['size']) ? ((float)$release['test_pack']['size']*1024*1024) : filesize($test_pack_path);
+		$tmp .= generate_latest_html_piece($release['test_pack']['path'], $test_pack_mtime, $test_pack_size, $version, $cur_ver);
+		unset($release['test_pack']);
 
 		foreach ($release as $flavour) {
-			$mtime = strtotime($flavour["mtime"]);
+			$mtime = strtotime($flavour['mtime']);
 
-			$tmp .= generate_latest_html_piece($flavour["zip"]["path"], $mtime, (float)$flavour["zip"]["size"]*1024*1024, $version, $cur_ver);
-			$tmp .= generate_latest_html_piece($flavour["debug_pack"]["path"], $mtime, (float)$flavour["debug_pack"]["size"]*1024*1024, $version, $cur_ver);
-			$tmp .= generate_latest_html_piece($flavour["devel_pack"]["path"], $mtime, (float)$flavour["devel_pack"]["size"]*1024*1024, $version, $cur_ver);
+			$tmp .= generate_latest_html_piece($flavour['zip']['path'], $mtime, (float)$flavour['zip']['size']*1024*1024, $version, $cur_ver);
+			$tmp .= generate_latest_html_piece($flavour['debug_pack']['path'], $mtime, (float)$flavour['debug_pack']['size']*1024*1024, $version, $cur_ver);
+			$tmp .= generate_latest_html_piece($flavour['devel_pack']['path'], $mtime, (float)$flavour['devel_pack']['size']*1024*1024, $version, $cur_ver);
 		}
 	}
 
-	$index_html_content = str_replace("RELEASES_LIST_PLACEHOLDER", $tmp, $index_html_tpl);
+	$index_html_content = str_replace('RELEASES_LIST_PLACEHOLDER', $tmp, $index_html_tpl);
 
 	if (!is_dir(dirname($index_html_path))) {
 		if (!mkdir(dirname($index_html_path))) {

--- a/script/generate_releases_json.bat
+++ b/script/generate_releases_json.bat
@@ -1,0 +1,1 @@
+c:\PHP7.2\php.exe -d error_reporting=E_ALL c:\domains\windows.php.net\script\generate_releases_json.php

--- a/script/generate_releases_json.php
+++ b/script/generate_releases_json.php
@@ -9,7 +9,6 @@ $releases = generate_listing('downloads/releases', MODE_RELEASE, 'c');
  * Change date format to ISO 8601
  * Altering date format in generate_listing() could break third-party scrapers
  */
-$timezone = new DateTimeZone('-07:00');
 foreach ($releases as &$release) {
     foreach ($release as &$flavour) {
         if (! is_array($flavour) || ! isset($flavour['mtime'])) {
@@ -17,7 +16,7 @@ foreach ($releases as &$release) {
         }
 
         try {
-            $date = new DateTimeImmutable($flavour['mtime'], $timezone);
+            $date = new DateTimeImmutable($flavour['mtime']);
             $flavour['mtime'] = $date->format('c');
         } catch (Exception $exception) {
             printf(

--- a/script/generate_releases_json.php
+++ b/script/generate_releases_json.php
@@ -3,5 +3,32 @@
 require_once __DIR__ . '/../include/config.php';
 require_once __DIR__ . '/../include/listing.php';
 
-$releases = generate_listing('downloads/releases', MODE_RELEASE);
+$releases = generate_listing('downloads/releases', MODE_RELEASE, 'c');
+
+/*
+ * Change date format to ISO 8601
+ * Altering date format in generate_listing() could break third-party scrapers
+ */
+$timezone = new DateTimeZone('-07:00');
+foreach ($releases as &$release) {
+    foreach ($release as &$flavour) {
+        if (! is_array($flavour) || ! isset($flavour['mtime'])) {
+            continue;
+        }
+
+        try {
+            $date = new DateTimeImmutable($flavour['mtime'], $timezone);
+            $flavour['mtime'] = $date->format('c');
+        } catch (Exception $exception) {
+            printf(
+                'An error occurred while trying to format date "%s": %s',
+                $flavour['mtime'],
+                $exception->getMessage()
+            );
+        }
+    }
+    unset($flavour);
+}
+unset($release);
+
 file_put_contents(RELEASES_DIR . 'releases.json', json_encode($releases));

--- a/script/generate_releases_json.php
+++ b/script/generate_releases_json.php
@@ -1,0 +1,7 @@
+<?php
+
+require_once __DIR__ . '/../include/config.php';
+require_once __DIR__ . '/../include/listing.php';
+
+$releases = generate_listing('downloads/releases', MODE_RELEASE);
+file_put_contents(RELEASES_DIR . 'releases.json', json_encode($releases));

--- a/script/generate_snap_page.php
+++ b/script/generate_snap_page.php
@@ -104,7 +104,7 @@ foreach ($active_branches as $branch_name) {
 	$rev_last = $revision;
 	$rev_dir = $branch_dir . '/' . $rev_last;
 	$rev_url = $branch_url  . '/' . $rev_last;
-	
+
 	$contents = file_get_contents($json_file);
 	$new = json_decode($contents, true);
 
@@ -173,4 +173,4 @@ include __DIR__ . '/../templates/snaps.php';
 $snaps = ob_get_contents();
 ob_end_clean();
 
-file_put_contents(DOCROOT . '/snapshot.html', $snaps);
+file_put_contents(DOCROOT . 'snapshot.html', $snaps);


### PR DESCRIPTION
This PR provides changes first discussed in https://bugs.php.net/bug.php?id=78140.

The new script `script/generate_releases_json.php` will create `docroot/downloads/releases/releases.json`, which contains a list of all current releases as generated by `generate_listing()` in `include/listing.php`.

This data is more easily machine-readable as the [directory listing](https://windows.php.net/downloads/releases/), plus it provides meta information like file size and hashes. A direct download link was added to the existing information. BC breaks should not be introduced with this PR.

`script/generate_releases_json.php` should be executed each time a new release is being published.

It could make sense to provide JSON data files for _archive_, _qa_ and _snaps_ as well. This would provide a uniform interface (though I haven't checked if that is possible).