### PR TITLE
Prepare for longer commit hashes

### DIFF
--- a/script/generate_snap_page.php
+++ b/script/generate_snap_page.php
@@ -105,7 +105,7 @@ foreach ($active_branches as $branch_name) {
 	/* Currently we always regenerate the snaps page completely. Alternatively, some more data might need
 		to be checked, for the case the script execution were caught at unlucky point where some build
 		upload is in the incomplete state. Both methods have their up and down sides. */
-	if ($force || substr($new['revision_last'], 0, 7) != substr($data[$branch_name]['revision_last'], 1)) {
+	if ($force || substr($new['revision_last'], 0, 10) != substr($data[$branch_name]['revision_last'], 1)) {
 		echo "new revision\n";
 		$has_new_revision = true;
 		$data[$branch_name] = $new;


### PR DESCRIPTION
The 7 digit hashes can produce collisions, so we're planning to use
10 digit hashes in the future.  This change prepares for that, although
that code is currently dead code, since `$force` is always true (see
the respective code comment).