### PR TITLE
Proposal: Use bold headers only for 64-bit downloads

### DIFF
--- a/docroot/listing.php
+++ b/docroot/listing.php
@@ -154,7 +154,7 @@ if (isset($versions[$major]['test_pack'])) {
 
 <?php if (isset($versions[$major][$minor])) {
 ?>
-		<div class="innerbox">
+		<div class="innerbox<?= stripos($minor, 'x86') !== false ? ' 32bit' : ''; ?>">
 		<span class="corners-top"><span></span></span>
 
 		<h4 id="php-<?php echo $major . '-' . $minor; ?>" name="php-<?php echo $major . '-' . $minor;?>"><?php echo $labels[$minor]; ?> (<?php echo $versions[$major][$minor]['mtime']; ?>)</h4>

--- a/docroot/styles/content.css
+++ b/docroot/styles/content.css
@@ -475,6 +475,10 @@
 	font-weight:bold;
 }
 
+.content .info .32bit h4 {
+	font-weight:normal;
+}
+
 .content .info h3 a {
 	color:#000;
 }

--- a/templates/left_column.php
+++ b/templates/left_column.php
@@ -93,6 +93,7 @@ if ((isset($mode) && ($mode == 'snapshots' || $mode == 'qa'))
 									<a name="x64"> </a>
 									<h4><u>amd64 (x86_64) Builds</u></h4>
 									<p><strong>PHP 7 provides full 64-bit support.</strong> The x64 builds of PHP 7 support native 64-bit integers, LFS, 64-bit memory_limit and much more.</p>
+									<p>x64 builds are recommended (almost all Windows installations support x64).</p>
 
 									<a name="long_path"></a>
 									<h4><u>Long and multibyte path</u></h4>


### PR DESCRIPTION
See https://externals.io/message/112808

I'd also considered something like `opacity: 0.6` for the entire section
but it seemed either hard to notice it was faded or illegible.

E.g. https://golang.org/dl/ uses bold for the most common x86-64
architecture.

Make the recommended download choice clearer for users unfamiliar
with the terms x86/x64.

- 64-bit PHP and libraries are generally more thoroughly tested
- 32-bit builds currently have the year 2038 problem
- 32-bit builds currently have incorrect values for stat() and filesize() for files larger than 2GB - https://www.php.net/filesize
- https://stackoverflow.com/a/41497867 suggests the vast majority of (desktop) windows installations are 64-bit

If only part of this makes sense, feel free to cherry-pick that.
**I haven't tested this yet** - this seems to assume it runs on the windows.php.net host

Also see https://externals.io/message/112808#112812
(A user that's deliberately choosing 32-bit php for memory/install size/performance reasons likely wouldn't pay attention to font weight)

> Overall I'm not really sure what to think about this. I personally don't
> have any idea how common PHP is used on 32-bit systems (are there any stats
> on that? From OS package installs, composer, etc?) and why it is used
> there. I know that running PHP on 32-bit is often faster, but I'm not sure
> if people explicitly chose to use 32-bit for that reason.

