### PR TITLE
Show PHP 8.4 (pre-)releases on the Website

### DIFF
--- a/docroot/listing.php
+++ b/docroot/listing.php
@@ -36,7 +36,7 @@ include __DIR__ . '/../include/listing.php';
 $baseurl = '/' . $dir_to_parse . '/';
 
 $versions = generate_listing($dir_to_parse, $nmode);
-$major_order = array('8.3', '8.2', '8.1');
+$major_order = array('8.4', '8.3', '8.2', '8.1');
 $minor_order = array(
 		'8.1' => array(
 			'nts-vs16-x64',
@@ -56,6 +56,12 @@ $minor_order = array(
 			'nts-vs16-x86',
 			'ts-vs16-x86'
 		),
+		'8.4' => array(
+			'nts-vs17-x64',
+			'ts-vs17-x64',
+			'nts-vs17-x86',
+			'ts-vs17-x86'
+		),
 	);
 
 $labels = array(
@@ -71,6 +77,10 @@ $labels = array(
 			'ts-vs16-x86'  => 'VS16 x86 Thread Safe',
 			'nts-vs16-x64' => 'VS16 x64 Non Thread Safe',
 			'ts-vs16-x64'  => 'VS16 x64 Thread Safe',
+			'nts-vs17-x86' => 'VS17 x86 Non Thread Safe',
+			'ts-vs17-x86'  => 'VS17 x86 Thread Safe',
+			'nts-vs17-x64' => 'VS17 x64 Non Thread Safe',
+			'ts-vs17-x64'  => 'VS17 x64 Thread Safe',
 );
 
 if ($mode == 'snapshots') {

--- a/news/2024-07-04-1.php
+++ b/news/2024-07-04-1.php
@@ -1,0 +1,15 @@
+<div class="info entry" id="news-2024-07-04-1">
+  <!-- .info -->
+  <h3 class="summary entry-title">PHP 8.4 builds use Visual Studio 2022</h3>
+  <?php news_date('04-Jul-2024') ?>
+  <div>
+    <p>
+      While previous minor versions of PHP 8 have been built with Visual Studio
+      2019 (aka. VS16), it is time to use Visual Studio 2022 (aka. VS17) for the
+      PHP 8.4 builds. To use these builds, you may need to install or update the
+      Visual C++ Redistributable for Visual Studio 2015-2022
+      <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">x64</a> or
+      <a href="https://aka.ms/vs/17/release/vc_redist.x86.exe">x86</a>.
+    </p>
+  </div>
+</div><!-- .info -->

--- a/templates/left_column.php
+++ b/templates/left_column.php
@@ -63,11 +63,11 @@ if ((isset($mode) && ($mode == 'snapshots' || $mode == 'qa'))
 
 									<p>With Apache, using the apache2handler SAPI, you have to use the Thread Safe (TS) versions of PHP.</p>
 
-									<h4><u>VC15 &amp; VS16</u></h4>
-									<p>More recent versions of PHP are built with VC15 or VS16 (Visual Studio 2017 or 2019 compiler respectively) and
+									<h4><u>VS16 &amp; VS17</u></h4>
+									<p>More recent versions of PHP are built with VS16 or VS17 (Visual Studio 2019 or 2022 compiler respectively) and
 									include improvements in performance and stability.</p>
 
-									<p> - The VC15 and VS16 builds require to have the <i>Visual C++ Redistributable for Visual Studio 2015-2019</i> <a href="https://aka.ms/vs/16/release/VC_redist.x64.exe">x64</a> or <a href="https://aka.ms/vs/16/release/VC_redist.x86.exe">x86</a> installed</p>
+									<p> - The VS16 and VS17 builds require to have the <i>Visual C++ Redistributable for Visual Studio 2015-2022</i> <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">x64</a> or <a href="https://aka.ms/vs/17/release/vc_redist.x86.exe">x86</a> installed</p>
 
 									<h4><u>TS and NTS</u></h4>
 									<p><strong>TS</strong> refers to multithread capable builds. <strong>NTS</strong> refers to single thread only builds. Use case for <strong>TS</strong> binaries involves interaction with


### PR DESCRIPTION
According to a quick discussion[1], these will be build with VS17 (aka. Visual Studio 2022), so we also update the respective info in the sidebar.

[1] <https://github.com/php/php-sdk-binary-tools/pull/5#issuecomment-2206216181>

---

I suggest to wait a bit with merging this commit, unless building with VS17 is uncontroversial (and until I'm able to do "proper" builds, after [the tests](https://github.com/cmb69/php-ftw/actions/runs/9784934000) have been successful). /cc @shivammathur, @bukka.