### PR TITLE
Update Team page

### DIFF
--- a/docroot/team.php
+++ b/docroot/team.php
@@ -52,12 +52,6 @@ include TPL_PATH . 'left_column.php';
 								Development and Q/A
 							</p>
 						</li>
-						<li>
-							<strong><a href="http://people.php.net/dalehirt">Dale Hirt</a></strong>
-							<p>
-								Team Leader, Automation
-							</p>
-						</li>
 					</ul>
                                </div><!-- .info -->
  
@@ -65,6 +59,12 @@ include TPL_PATH . 'left_column.php';
                                    <h3 class="summary entry-title">Former Team Members</h3>
                                    <p></p>
 					<ul class="flex">
+						<li>
+							<strong>Dale Hirt</strong>
+							<p>
+								Team Leader, Automation
+							</p>
+						</li>
 						<li>
 							<strong>Pierre Joye</strong>
 							<p>


### PR DESCRIPTION
It seems to me this page is grossly out-dated. Dale is almost certainly no longer active, I don't know about Kalle, and maybe Anatol could be moved to the former members section, too.

Maybe more importantly, it appears to make sense to add @shivammathur, and/or others who are working on the transition of windows.php.net.

And I don't know whether anyone of the "PHP for Windows team" is still active on #winphp-dev on freenode. If not, this contact should be removed as well.

/cc @jimwins, since your [recent addition to the Wiki](https://wiki.php.net/systems/windows?rev=1722642077&do=diff) triggered this PR. FWIW, I have FTP access to that machine (and maybe Anatol, too), but almost certainly only Alex has full access.