### PR TITLE
Update note to download from Apache Lounge

### DIFF
--- a/templates/left_column.php
+++ b/templates/left_column.php
@@ -57,8 +57,8 @@ if ((isset($mode) && ($mode == 'snapshots' || $mode == 'qa'))
 									<p>If you are using PHP as FastCGI with IIS you should use the Non-Thread Safe (NTS) versions of PHP.</p>
 
 									<h4><u>Apache</u></h4>
-									<p>Please use the Apache builds provided by <a href="http://apachelounge.com">Apache Lounge</a>.
-									They provide VC15 and VS16 builds of Apache for x86 and x64.
+									<p>Please use the Apache HTTP Server builds provided by <a href="https://www.apachelounge.com/download/">Apache Lounge</a>.
+									They provide VC16 and VS17 builds of Apache for x86 and x64.
 									We use their binaries to build the Apache SAPIs.</p>
 
 									<p>With Apache, using the apache2handler SAPI, you have to use the Thread Safe (TS) versions of PHP.</p>


### PR DESCRIPTION
When [added](https://github.com/php/web-windows/commit/3e559338b1c2da683f124e7ea223eba1ce389770) 12 years ago this may have made sense, but Apache Lounge no longer builds or even offers versions of PHP for download